### PR TITLE
bugfix: command J uses hex address, but se_default.txt can not parse "J 0x11" correctly

### DIFF
--- a/Applications/ocra/assembler.py
+++ b/Applications/ocra/assembler.py
@@ -114,9 +114,8 @@ class Assembler:
 
 		# Format A
 		elif self.opcode_table[opcode][1] == 'A':
-			reg_addr = format(int(line[1], 10), 'b').zfill(5)
-			print(reg_addr)
 			if opcode == 'LD64' or opcode == 'JNZ': # Reg and addr specified
+				reg_addr = format(int(line[1], 10), 'b').zfill(5)
 				if line[2] in self.var_table.keys():
 					addr = self.var_table[line[2]] # Look up address of variable
 					print(self.var_table)
@@ -132,6 +131,7 @@ class Assembler:
 				dir_addr = format(int(addr), 'b').zfill(32)
 
 			elif opcode == 'DEC' or opcode == 'INC': # Reg specified
+				reg_addr = format(int(line[1], 10), 'b').zfill(5)
 				dir_addr = '0'.zfill(32)
 
 			else: # Addr specified


### PR DESCRIPTION
As described in [GUI](https://openmri.github.io/ocra/gui) page, and in [code](https://github.com/OpenMRI/ocra/blob/master/Applications/ocra/assembler.py#L138) , 

"J" command should have hex address parameter, but parser will not work properly if I write something like "J 0x1A", "J 0x11"

This MR is trying to fix this