### PR TITLE
Feature/switch rx channels

### DIFF
--- a/Applications/relax2/poetry.lock
+++ b/Applications/relax2/poetry.lock
@@ -26,7 +26,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "fonttools"
-version = "4.39.0"
+version = "4.39.2"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -273,7 +273,10 @@ content-hash = "d91f94789b834755329a2b187c53a3c0fe903c8a52ab11c39a26eeb7ac0d9478
 [metadata.files]
 contourpy = []
 cycler = []
-fonttools = []
+fonttools = [
+    {file = "fonttools-4.39.2-py3-none-any.whl", hash = "sha256:85245aa2fd4cf502a643c9a9a2b5a393703e150a6eaacc3e0e84bb448053f061"},
+    {file = "fonttools-4.39.2.zip", hash = "sha256:e2d9f10337c9e3b17f9bce17a60a16a885a7d23b59b7f45ce07ea643e5580439"},
+]
 importlib-resources = []
 kiwisolver = []
 matplotlib = []

--- a/Applications/relax2/server/relax_server_dev.c
+++ b/Applications/relax2/server/relax_server_dev.c
@@ -8469,7 +8469,7 @@ int main(int argc)
   int fd, sock_server, sock_client, conn_status;
   void *cfg, *sts;
   volatile uint32_t *slcr, *rx_freq, *rx_rate, *seq_config, *pulseq_memory, *tx_divider;
-  volatile uint16_t *rx_cntr, *tx_size;
+  volatile uint16_t *rx_cntr, *tx_size, *rx_switch;
   //volatile uint8_t *rx_rst, *tx_rst;
   volatile uint64_t *rx_data;
   void *tx_data;

--- a/Applications/relax2/server/relax_server_dev.c
+++ b/Applications/relax2/server/relax_server_dev.c
@@ -8565,6 +8565,9 @@ int main(int argc)
   //tx_rst = ((uint8_t *)(cfg + 1));
   tx_size = ((uint16_t *)(cfg + 12));
 
+  //rx_switch
+  rx_switch = ((uint16_t *)(cfg + 6));
+  
   printf("Setting FPGA clock to 143 MHz !\n"); fflush(stdout);
 
   // set FPGA clock to 143 MHz
@@ -8762,7 +8765,8 @@ int main(int argc)
         printf("Set RX mode.\n");
         int rxmode = (int)command[36];
         printf("RX mode: %d \n", rxmode);
-        // 0 = no RX, 1 = RX1, 2 = RX2, 3 = RX1 and RX2
+        // 1 = RX1, 2 = RX2, 0, 3 = RX1 and RX2
+	*rx_switch = rxmode & (0x0003);
         continue;
       }
       

--- a/HDL/Makefile
+++ b/HDL/Makefile
@@ -15,7 +15,7 @@ CORES_PAVEL = axi_axis_reader_v1_0 axi_axis_writer_v1_0 axi_bram_reader_v1_0 \
         axis_zeroer_v1_0 axis_variable_v1_0 axis_interpolator_v1_0 \
         axi_sts_register_v1_0
 
-CORES = micro_sequencer_v1_0 axi_dac_spi_sequencer_v1_1 axi_dac_daisy_spi_sequencer_v1_0 axis_segmented_bram_reader_v1_0 axi_serial_attenuator_v1_0 axi_four_ltc2656_spi_v1_0 axi_trigger_core_v1_0
+CORES = micro_sequencer_v1_0 axi_dac_spi_sequencer_v1_1 axi_dac_daisy_spi_sequencer_v1_0 axis_segmented_bram_reader_v1_0 axi_serial_attenuator_v1_0 axi_four_ltc2656_spi_v1_0 axi_trigger_core_v1_0 axis_red_pitaya_adc_v3_0
 
 VIVADO = vivado -nolog -nojournal -mode batch
 HSI = xsct

--- a/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
+++ b/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
@@ -26,7 +26,8 @@ module axis_red_pitaya_adc #
    
   reg  [ADC_DATA_WIDTH-1:0] int_dat_a_reg;
   reg  [ADC_DATA_WIDTH-1:0] int_dat_b_reg;
-
+   reg [1:0] 		    int_channel_switch;
+   
   always @(posedge aclk)
   begin
     int_dat_a_reg <= adc_dat_a;

--- a/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
+++ b/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
@@ -1,0 +1,49 @@
+
+`timescale 1 ns / 1 ps
+
+module axis_red_pitaya_adc #
+(
+  parameter integer ADC_DATA_WIDTH = 14,
+  parameter integer AXIS_TDATA_WIDTH = 32
+)
+(
+  // System signals
+  input wire 			     aclk,
+
+  // ADC signals
+  output wire 			     adc_csn,
+  input wire [ADC_DATA_WIDTH-1:0]    adc_dat_a,
+  input wire [ADC_DATA_WIDTH-1:0]    adc_dat_b,
+
+  // Control signals for the switch
+  input wire [1:0]                   adc_channel_switch,     
+  // Master side
+  output wire  			     m_axis_tvalid,
+  output wire [AXIS_TDATA_WIDTH-1:0] m_axis_tdata
+);
+  localparam PADDING_WIDTH = AXIS_TDATA_WIDTH/2 - ADC_DATA_WIDTH;
+  localparam SINGLE_PADDING_WIDTH = AXIS_TDATA_WIDTH - ADC_DATA_WIDTH;
+   
+  reg  [ADC_DATA_WIDTH-1:0] int_dat_a_reg;
+  reg  [ADC_DATA_WIDTH-1:0] int_dat_b_reg;
+
+  always @(posedge aclk)
+  begin
+    int_dat_a_reg <= adc_dat_a;
+    int_dat_b_reg <= adc_dat_b;
+    int_channel_switch <= adc_channel_switch,
+  end
+
+  assign adc_csn = 1'b1;
+
+  assign m_axis_tvalid = 1'b1;
+
+  assign tdata = (sel == 3'b000) ? data_in_0 :
+                 (sel == 3'b001) ? data_in_1 :
+                                   data_in_2;   
+  assign m_axis_tdata = (int_channel_switch == 2'b01) ? {{(PADDING_WIDTH+1){int_dat_a_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_a_reg[ADC_DATA_WIDTH-2:0]} :
+			(int_channel_switch == 2'b10) ? {{(PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0]} :
+			                                {{(PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0],
+                                                        {(PADDING_WIDTH+1){int_dat_a_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_a_reg[ADC_DATA_WIDTH-2:0]};
+
+endmodule

--- a/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
+++ b/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
@@ -41,8 +41,8 @@ module axis_red_pitaya_adc #
   assign tdata = (sel == 3'b000) ? data_in_0 :
                  (sel == 3'b001) ? data_in_1 :
                                    data_in_2;   
-  assign m_axis_tdata = (int_channel_switch == 2'b01) ? {{(PADDING_WIDTH+1){int_dat_a_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_a_reg[ADC_DATA_WIDTH-2:0]} :
-			(int_channel_switch == 2'b10) ? {{(PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0]} :
+  assign m_axis_tdata = (int_channel_switch == 2'b01) ? {{(SINGLE_PADDING_WIDTH+1){int_dat_a_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_a_reg[ADC_DATA_WIDTH-2:0]} :
+			(int_channel_switch == 2'b10) ? {{(SINGLE_PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0]} :
 			                                {{(PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0],
                                                         {(PADDING_WIDTH+1){int_dat_a_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_a_reg[ADC_DATA_WIDTH-2:0]};
 

--- a/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
+++ b/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
@@ -31,16 +31,14 @@ module axis_red_pitaya_adc #
   begin
     int_dat_a_reg <= adc_dat_a;
     int_dat_b_reg <= adc_dat_b;
-    int_channel_switch <= adc_channel_switch,
+    int_channel_switch <= adc_channel_switch;
+     
   end
 
   assign adc_csn = 1'b1;
 
   assign m_axis_tvalid = 1'b1;
-
-  assign tdata = (sel == 3'b000) ? data_in_0 :
-                 (sel == 3'b001) ? data_in_1 :
-                                   data_in_2;   
+ 
   assign m_axis_tdata = (int_channel_switch == 2'b01) ? {{(SINGLE_PADDING_WIDTH+1){int_dat_a_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_a_reg[ADC_DATA_WIDTH-2:0]} :
 			(int_channel_switch == 2'b10) ? {{(SINGLE_PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0]} :
 			                                {{(PADDING_WIDTH+1){int_dat_b_reg[ADC_DATA_WIDTH-1]}}, ~int_dat_b_reg[ADC_DATA_WIDTH-2:0],

--- a/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
+++ b/HDL/cores/axis_red_pitaya_adc_v3_0/axis_red_pitaya_adc.v
@@ -33,7 +33,6 @@ module axis_red_pitaya_adc #
     int_dat_a_reg <= adc_dat_a;
     int_dat_b_reg <= adc_dat_b;
     int_channel_switch <= adc_channel_switch;
-     
   end
 
   assign adc_csn = 1'b1;

--- a/HDL/cores/axis_red_pitaya_adc_v3_0/core_config.tcl
+++ b/HDL/cores/axis_red_pitaya_adc_v3_0/core_config.tcl
@@ -1,0 +1,17 @@
+set display_name {AXI4-Stream Red Pitaya ADC}
+
+set core [ipx::current_core]
+
+set_property DISPLAY_NAME $display_name $core
+set_property DESCRIPTION $display_name $core
+
+core_parameter AXIS_TDATA_WIDTH {AXIS TDATA WIDTH} {Width of the M_AXIS data bus.}
+core_parameter ADC_DATA_WIDTH {ADC DATA WIDTH} {Width of the ADC data bus.}
+
+set bus [ipx::get_bus_interfaces -of_objects $core m_axis]
+set_property NAME M_AXIS $bus
+set_property INTERFACE_MODE master $bus
+
+set bus [ipx::get_bus_interfaces aclk]
+set parameter [ipx::add_bus_parameter ASSOCIATED_BUSIF $bus]
+set_property VALUE M_AXIS $parameter

--- a/HDL/projects/ocra_mri/block_design.tcl
+++ b/HDL/projects/ocra_mri/block_design.tcl
@@ -37,6 +37,43 @@ cell xilinx.com:ip:clk_wiz:6.0 pll_0 {
   clk_in1_n adc_clk_n_i
 }
 
+# Create axi_cfg_register
+cell pavel-demin:user:axi_cfg_register:1.0 cfg_0 {
+  CFG_DATA_WIDTH 128
+  AXI_ADDR_WIDTH 32
+  AXI_DATA_WIDTH 32
+}
+
+# Create slice with the TX configuration, which uses the bottom 32 bits
+cell xilinx.com:ip:xlslice:1.0 txinterpolator_slice_0 {
+  DIN_WIDTH 128 DIN_FROM 31 DIN_TO 0 DOUT_WIDTH 32
+} {
+  Din cfg_0/cfg_data
+}
+
+# Create slice with the RX configuration and NCO configuration
+# RX seems to use the bottom 16 bit
+# NCO uses the upper 32 bit
+# Bits 63 to 48 seem free, USING bits 49,48 FOR ADC switch then
+cell xilinx.com:ip:xlslice:1.0 cfg_slice_0 {
+  DIN_WIDTH 128 DIN_FROM 95 DIN_TO 32 DOUT_WIDTH 64
+} {
+  Din cfg_0/cfg_data
+}
+
+# ADC switch slice
+cell xilinx.com:ip:xlslice:1.0 cfg_adc_switch {
+  DIN_WIDTH 128 DIN_FROM 48 DIN_TO 48 DOUT_WIDTH 2
+} {
+  Din cfg_0/cfg_data
+}
+
+# Create another slice with data for the TX, which is another 32 bit
+cell xilinx.com:ip:xlslice:1.0 cfg_slice_1 {
+  DIN_WIDTH 128 DIN_FROM 127 DIN_TO 96 DOUT_WIDTH 32
+} {
+  Din cfg_0/cfg_data
+}
 # ADC
 
 # Create axis_red_pitaya_adc
@@ -45,6 +82,7 @@ cell open-mri:user:axis_red_pitaya_adc:3.0 adc_0 {} {
   adc_dat_a adc_dat_a_i
   adc_dat_b adc_dat_b_i
   adc_csn adc_csn_o
+  adc_channel_switch cfg_adc_switch
 }
 
 # Create axis_red_pitaya_dac
@@ -59,40 +97,6 @@ cell pavel-demin:user:axis_red_pitaya_dac:1.0 dac_0 {} {
   dac_dat dac_dat_o
 }
 
-# Create axi_cfg_register
-cell pavel-demin:user:axi_cfg_register:1.0 cfg_0 {
-  CFG_DATA_WIDTH 128
-  AXI_ADDR_WIDTH 32
-  AXI_DATA_WIDTH 32
-}
-
-# Create xlslice
-cell xilinx.com:ip:xlslice:1.0 txinterpolator_slice_0 {
-  DIN_WIDTH 128 DIN_FROM 31 DIN_TO 0 DOUT_WIDTH 32
-} {
-  Din cfg_0/cfg_data
-}
-
-# Create xlslice
-#cell xilinx.com:ip:xlslice:1.0 rst_slice_1 {
-#  DIN_WIDTH 128 DIN_FROM 15 DIN_TO 8 DOUT_WIDTH 8
-#} {
-#  Din cfg_0/cfg_data
-#}
-
-# Create xlslice
-cell xilinx.com:ip:xlslice:1.0 cfg_slice_0 {
-  DIN_WIDTH 128 DIN_FROM 95 DIN_TO 32 DOUT_WIDTH 64
-} {
-  Din cfg_0/cfg_data
-}
-
-# Create xlslice
-cell xilinx.com:ip:xlslice:1.0 cfg_slice_1 {
-  DIN_WIDTH 128 DIN_FROM 127 DIN_TO 96 DOUT_WIDTH 32
-} {
-  Din cfg_0/cfg_data
-}
 
 # Create xlconstant
 cell xilinx.com:ip:xlconstant:1.1 const_0

--- a/HDL/projects/ocra_mri/block_design.tcl
+++ b/HDL/projects/ocra_mri/block_design.tcl
@@ -52,8 +52,8 @@ cell xilinx.com:ip:xlslice:1.0 txinterpolator_slice_0 {
 }
 
 # Create slice with the RX configuration and NCO configuration
-# RX seems to use the bottom 16 bit
-# NCO uses the upper 32 bit
+# RX seems to use the bottom 16 bit of the upper 32 bit
+# NCO uses the bottom 32 bit
 # Bits 63 to 48 seem free, USING bits 49,48 FOR ADC switch then
 cell xilinx.com:ip:xlslice:1.0 cfg_slice_0 {
   DIN_WIDTH 128 DIN_FROM 95 DIN_TO 32 DOUT_WIDTH 64

--- a/HDL/projects/ocra_mri/block_design.tcl
+++ b/HDL/projects/ocra_mri/block_design.tcl
@@ -40,7 +40,7 @@ cell xilinx.com:ip:clk_wiz:6.0 pll_0 {
 # ADC
 
 # Create axis_red_pitaya_adc
-cell pavel-demin:user:axis_red_pitaya_adc:2.0 adc_0 {} {
+cell open-mri:user:axis_red_pitaya_adc:3.0 adc_0 {} {
   aclk pll_0/clk_out1
   adc_dat_a adc_dat_a_i
   adc_dat_b adc_dat_b_i

--- a/HDL/projects/ocra_mri/block_design.tcl
+++ b/HDL/projects/ocra_mri/block_design.tcl
@@ -63,7 +63,7 @@ cell xilinx.com:ip:xlslice:1.0 cfg_slice_0 {
 
 # ADC switch slice
 cell xilinx.com:ip:xlslice:1.0 cfg_adc_switch {
-  DIN_WIDTH 128 DIN_FROM 48 DIN_TO 48 DOUT_WIDTH 2
+  DIN_WIDTH 128 DIN_FROM 49 DIN_TO 48 DOUT_WIDTH 2
 } {
   Din cfg_0/cfg_data
 }
@@ -82,7 +82,7 @@ cell open-mri:user:axis_red_pitaya_adc:3.0 adc_0 {} {
   adc_dat_a adc_dat_a_i
   adc_dat_b adc_dat_b_i
   adc_csn adc_csn_o
-  adc_channel_switch cfg_adc_switch
+    adc_channel_switch cfg_adc_switch/Dout
 }
 
 # Create axis_red_pitaya_dac

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Seriously though, this repository is mostly code generated back in 2017 to demon
 If you're interested in learning more about getting started with OCRA, check out [The OCRA github page](https://openmri.github.io/ocra/).
 
 We also have a blog page about some of the hardware at the [The OCRA blog](https://zeugmatographix.org/ocra/2020/07/23/welcome-to-the-ocra-blog/)
+
+Its not straight-forward to build the FPGA bitfiles, at least until we provide better documentation. Until then, please find the bitfiles for the tabletop OCRA MRI setups here:
+[Downloadable binaries](https://drive.google.com/drive/folders/1gWpjpM8BfPyvGyobRKDbgHXIaMaJ5J4R?usp=share_link)


### PR DESCRIPTION
Incorporate a multiplexer that allows switching of the ADC data source. The control is done by bits 49:48 of the control register as follows:

2'b00, 2b'11: backwards compatible behavior with both channels stacked together in padded 32 bit word
2'b01: only channel A, padded in bottom 14bit of the 32 bit word
2'b10: only channel B, padded in bottom 14bit of the 32 bit word.
