### PR TITLE
(feature) kspace cutout circular

### DIFF
--- a/Applications/relax2/Relax2_main.py
+++ b/Applications/relax2/Relax2_main.py
@@ -363,6 +363,9 @@ class ParametersWindow(Para_Window_Form, Para_Window_Base):
         
         self.Images_Plot_radioButton.toggled.connect(self.update_params)
         
+        self.kspace_cut_circ_radioButton.toggled.connect(self.update_params)
+        self.kspace_cut_rec_radioButton.toggled.connect(self.update_params)
+        
         self.kSpace_Cut_Center_radioButton.toggled.connect(self.update_params)
         self.kSpace_Cut_Outside_radioButton.toggled.connect(self.update_params)
         self.kSpace_Cut_Center_spinBox.setKeyboardTracking(False)
@@ -497,6 +500,9 @@ class ParametersWindow(Para_Window_Form, Para_Window_Base):
         self.Average_spinBox.setValue(params.averagecount)
         
         if params.imagplots == 1: self.Images_Plot_radioButton.setChecked(True)
+        
+        if params.cutcirc == 1: self.kspace_cut_circ_radioButton.setChecked(True)
+        if params.cutrec == 1: self.kspace_cut_rec_radioButton.setChecked(True)
         
         if params.cutcenter == 1: self.kSpace_Cut_Center_radioButton.setChecked(True)
         if params.cutoutside == 1: self.kSpace_Cut_Outside_radioButton.setChecked(True)
@@ -666,6 +672,11 @@ class ParametersWindow(Para_Window_Form, Para_Window_Base):
         
         if self.Images_Plot_radioButton.isChecked(): params.imagplots = 1
         else: params.imagplots = 0
+        
+        if self.kspace_cut_circ_radioButton.isChecked(): params.cutcirc = 1
+        else: params.cutcirc = 0
+        if self.kspace_cut_rec_radioButton.isChecked(): params.cutrec = 1
+        else: params.cutrec = 0
         
         if self.kSpace_Cut_Center_radioButton.isChecked(): params.cutcenter = 1
         else: params.cutcenter = 0

--- a/Applications/relax2/parameter_handler.py
+++ b/Applications/relax2/parameter_handler.py
@@ -117,6 +117,8 @@ class Parameters:
         self.average = 0
         self.averagecount = 10
         self.imagplots = 0
+        self.cutcirc = 0
+        self.cutrec = 0
         self.cutcenter = 0
         self.cutoutside = 0
         self.cutcentervalue = 0
@@ -232,6 +234,8 @@ class Parameters:
                          self.average, \
                          self.averagecount, \
                          self.imagplots, \
+                         self.cutcirc, \
+                         self.cutrec, \
                          self.cutcenter, \
                          self.cutoutside, \
                          self.cutcentervalue, \
@@ -378,6 +382,8 @@ class Parameters:
                 self.average, \
                 self.averagecount, \
                 self.imagplots, \
+                self.cutcirc, \
+                self.cutrec, \
                 self.cutcenter, \
                 self.cutoutside, \
                 self.cutcentervalue, \

--- a/Applications/relax2/process_handler.py
+++ b/Applications/relax2/process_handler.py
@@ -85,22 +85,38 @@ class process:
                 for m in range(int(params.usphaseidx/2)):
                     params.kspace[int(n*params.usphaseidx+m),:] = 0
 
+        if params.cutcirc == 1:
+            #Set kSpace to 0 (Option)
+            self.cutc = params.kspace.shape[1] / 2 * params.cutcentervalue / 100
+            self.cuto = params.kspace.shape[1] / 2 * (1 - params.cutoutsidevalue / 100)
 
-                    
-        #Set kSpace to 0 (Option)
-        self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
-        self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
-        self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
-        self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
-        
-        if params.cutcenter == 1:
-            params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            if params.cutcenter == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) <= self.cutc:
+                            params.kspace[jj,ii] = 0
+                            
+            if params.cutoutside == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) >= self.cuto:
+                            params.kspace[jj,ii] = 0
             
-        if params.cutoutside == 1:
-            params.kspace[0:self.cutoy, :] = 0
-            params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
-            params.kspace[:, 0:self.cutox] = 0
-            params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
+        if params.cutrec == 1:
+            #Set kSpace to 0 (Option)
+            self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
+            self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
+            self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
+            self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
+        
+            if params.cutcenter == 1:
+                params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            
+            if params.cutoutside == 1:
+                params.kspace[0:self.cutoy, :] = 0
+                params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
+                params.kspace[:, 0:self.cutox] = 0
+                params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
             
         #Image calculations
         self.k_amp_full = np.abs(params.kspace)
@@ -146,22 +162,40 @@ class process:
                 for m in range(int(params.usphaseidx/2)):
                     params.kspace[:,int(n*params.usphaseidx+m),:] = 0
 
+        if params.cutcirc == 1:
+            #Set kSpace to 0 (Option)
+            self.cutc = params.kspace.shape[2] / 2 * params.cutcentervalue / 100
+            self.cuto = params.kspace.shape[2] / 2 * (1 - params.cutoutsidevalue / 100)
 
-                    
-        #Set kSpace to 0 (Option)
-        self.cutcx = int(params.kspace.shape[2] / 2 * params.cutcentervalue / 100)
-        self.cutcy = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
-        self.cutox = int(params.kspace.shape[2] / 2 * params.cutoutsidevalue / 100)
-        self.cutoy = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
-        
-        if params.cutcenter == 1:
-            params.kspace[:,self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            if params.cutcenter == 1:
+                for kk in range(params.kspace.shape[0]):
+                    for ii in range(params.kspace.shape[2]):
+                        for jj in range(params.kspace.shape[1]):
+                            if np.sqrt((ii - (params.kspace.shape[2]/2))**2 + (jj * params.kspace.shape[2]/params.kspace.shape[1] - (params.kspace.shape[2]/2))**2) <= self.cutc:
+                                params.kspace[kk,jj,ii] = 0
+                            
+            if params.cutoutside == 1:
+                for kk in range(params.kspace.shape[0]):
+                    for ii in range(params.kspace.shape[2]):
+                        for jj in range(params.kspace.shape[1]):
+                            if np.sqrt((ii - (params.kspace.shape[2]/2))**2 + (jj * params.kspace.shape[2]/params.kspace.shape[1] - (params.kspace.shape[2]/2))**2) >= self.cuto:
+                                params.kspace[kk,jj,ii] = 0
             
-        if params.cutoutside == 1:
-            params.kspace[:,0:self.cutoy, :] = 0
-            params.kspace[:,params.kspace.shape[1] - self.cutoy:params.kspace.shape[1], :] = 0
-            params.kspace[:,:, 0:self.cutox] = 0
-            params.kspace[:,:, params.kspace.shape[2] - self.cutox:params.kspace.shape[2]] = 0
+        if params.cutrec == 1:
+            #Set kSpace to 0 (Option)
+            self.cutcx = int(params.kspace.shape[2] / 2 * params.cutcentervalue / 100)
+            self.cutcy = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
+            self.cutox = int(params.kspace.shape[2] / 2 * params.cutoutsidevalue / 100)
+            self.cutoy = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
+        
+            if params.cutcenter == 1:
+                params.kspace[:,self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            
+            if params.cutoutside == 1:
+                params.kspace[:,0:self.cutoy, :] = 0
+                params.kspace[:,params.kspace.shape[1] - self.cutoy:params.kspace.shape[1], :] = 0
+                params.kspace[:,:, 0:self.cutox] = 0
+                params.kspace[:,:, params.kspace.shape[2] - self.cutox:params.kspace.shape[2]] = 0
             
         #Image calculations
         self.k_amp_full = np.abs(params.kspace)
@@ -200,20 +234,38 @@ class process:
                 for m in range(int(params.usphaseidx/2)):
                     params.kspace[int(n*params.usphaseidx+m),:] = 0
        
-        #Set kSpace to 0 (Option)
-        self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
-        self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
-        self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
-        self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
-        
-        if params.cutcenter == 1:
-            params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+        if params.cutcirc == 1:
+            #Set kSpace to 0 (Option)
+            self.cutc = params.kspace.shape[1] / 2 * params.cutcentervalue / 100
+            self.cuto = params.kspace.shape[1] / 2 * (1 - params.cutoutsidevalue / 100)
+
+            if params.cutcenter == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) <= self.cutc:
+                            params.kspace[jj,ii] = 0
+                            
+            if params.cutoutside == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) >= self.cuto:
+                            params.kspace[jj,ii] = 0
             
-        if params.cutoutside == 1:
-            params.kspace[0:self.cutoy, :] = 0
-            params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
-            params.kspace[:, 0:self.cutox] = 0
-            params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
+        if params.cutrec == 1:
+            #Set kSpace to 0 (Option)
+            self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
+            self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
+            self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
+            self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
+        
+            if params.cutcenter == 1:
+                params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            
+            if params.cutoutside == 1:
+                params.kspace[0:self.cutoy, :] = 0
+                params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
+                params.kspace[:, 0:self.cutox] = 0
+                params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
             
         #Image calculations
         self.k_amp_full = np.abs(params.kspace)
@@ -248,15 +300,38 @@ class process:
                 for m in range(int(params.usphaseidx/2)):
                     self.kspacediff[int(n*params.usphaseidx+m),:] = 0
 
-        #Set kSpace to 0 (Option)
-        if params.cutcenter == 1:
-            self.kspacediff[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+        if params.cutcirc == 1:
+            #Set kSpace to 0 (Option)
+            self.cutc = params.kspace.shape[1] / 2 * params.cutcentervalue / 100
+            self.cuto = params.kspace.shape[1] / 2 * (1 - params.cutoutsidevalue / 100)
+
+            if params.cutcenter == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) <= self.cutc:
+                            params.kspace[jj,ii] = 0
+                            
+            if params.cutoutside == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) >= self.cuto:
+                            params.kspace[jj,ii] = 0
             
-        if params.cutoutside == 1:
-            self.kspacediff[0:self.cutoy, :] = 0
-            self.kspacediff[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
-            self.kspacediff[:, 0:self.cutox] = 0
-            self.kspacediff[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
+        if params.cutrec == 1:
+            #Set kSpace to 0 (Option)
+            self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
+            self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
+            self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
+            self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
+        
+            if params.cutcenter == 1:
+                params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            
+            if params.cutoutside == 1:
+                params.kspace[0:self.cutoy, :] = 0
+                params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
+                params.kspace[:, 0:self.cutox] = 0
+                params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
             
         #Image calculations
         self.k_amp_full = np.abs(self.kspacediff)
@@ -300,20 +375,38 @@ class process:
 
 
                     
-        #Set kSpace to 0 (Option)
-        self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
-        self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
-        self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
-        self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
-        
-        if params.cutcenter == 1:
-            params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+        if params.cutcirc == 1:
+            #Set kSpace to 0 (Option)
+            self.cutc = params.kspace.shape[1] / 2 * params.cutcentervalue / 100
+            self.cuto = params.kspace.shape[1] / 2 * (1 - params.cutoutsidevalue / 100)
+
+            if params.cutcenter == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) <= self.cutc:
+                            params.kspace[jj,ii] = 0
+                            
+            if params.cutoutside == 1:
+                for ii in range(params.kspace.shape[1]):
+                    for jj in range(params.kspace.shape[0]):
+                        if np.sqrt((ii - (params.kspace.shape[1]/2))**2 + (jj * params.kspace.shape[1]/params.kspace.shape[0] - (params.kspace.shape[1]/2))**2) >= self.cuto:
+                            params.kspace[jj,ii] = 0
             
-        if params.cutoutside == 1:
-            params.kspace[0:self.cutoy, :] = 0
-            params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
-            params.kspace[:, 0:self.cutox] = 0
-            params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
+        if params.cutrec == 1:
+            #Set kSpace to 0 (Option)
+            self.cutcx = int(params.kspace.shape[1] / 2 * params.cutcentervalue / 100)
+            self.cutcy = int(params.kspace.shape[0] / 2 * params.cutcentervalue / 100)
+            self.cutox = int(params.kspace.shape[1] / 2 * params.cutoutsidevalue / 100)
+            self.cutoy = int(params.kspace.shape[0] / 2 * params.cutoutsidevalue / 100)
+        
+            if params.cutcenter == 1:
+                params.kspace[self.kspace_centery - self.cutcy:self.kspace_centery + self.cutcy, self.kspace_centerx - self.cutcx:self.kspace_centerx + self.cutcx] = 0
+            
+            if params.cutoutside == 1:
+                params.kspace[0:self.cutoy, :] = 0
+                params.kspace[params.kspace.shape[0] - self.cutoy:params.kspace.shape[0], :] = 0
+                params.kspace[:, 0:self.cutox] = 0
+                params.kspace[:, params.kspace.shape[1] - self.cutox:params.kspace.shape[1]] = 0
             
         #Image calculations
         self.k_amp_full = np.abs(params.kspace)

--- a/Applications/relax2/ui/parameters.ui
+++ b/Applications/relax2/ui/parameters.ui
@@ -36,19 +36,19 @@
    </property>
    <layout class="QGridLayout" name="gridLayout">
     <property name="leftMargin">
-     <number>5</number>
+     <number>0</number>
     </property>
     <property name="topMargin">
-     <number>5</number>
+     <number>0</number>
     </property>
     <property name="rightMargin">
-     <number>5</number>
+     <number>0</number>
     </property>
     <property name="bottomMargin">
-     <number>5</number>
+     <number>0</number>
     </property>
     <property name="spacing">
-     <number>5</number>
+     <number>0</number>
     </property>
     <item row="5" column="2">
      <widget class="QSpinBox" name="Flipangle_Amplitude_spinBox">
@@ -2815,106 +2815,6 @@
       </property>
      </widget>
     </item>
-    <item row="27" column="3">
-     <widget class="QRadioButton" name="kSpace_Cut_Center_radioButton">
-      <property name="minimumSize">
-       <size>
-        <width>200</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Center to 0 [%]</string>
-      </property>
-      <property name="autoExclusive">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="28" column="3">
-     <widget class="QRadioButton" name="kSpace_Cut_Outside_radioButton">
-      <property name="minimumSize">
-       <size>
-        <width>200</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Outside to 0 [%]</string>
-      </property>
-      <property name="autoExclusive">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="27" column="4">
-     <widget class="QSpinBox" name="kSpace_Cut_Center_spinBox">
-      <property name="minimumSize">
-       <size>
-        <width>150</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>150</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="minimum">
-       <number>1</number>
-      </property>
-      <property name="maximum">
-       <number>100</number>
-      </property>
-      <property name="value">
-       <number>10</number>
-      </property>
-     </widget>
-    </item>
-    <item row="28" column="4">
-     <widget class="QSpinBox" name="kSpace_Cut_Outside_spinBox">
-      <property name="minimumSize">
-       <size>
-        <width>150</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>150</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="minimum">
-       <number>1</number>
-      </property>
-      <property name="maximum">
-       <number>100</number>
-      </property>
-      <property name="value">
-       <number>10</number>
-      </property>
-     </widget>
-    </item>
     <item row="3" column="5">
      <widget class="QLabel" name="label_3">
       <property name="minimumSize">
@@ -2980,6 +2880,154 @@
         </property>
         <property name="text">
          <string>RX2</string>
+        </property>
+        <property name="autoExclusive">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="29" column="3">
+     <widget class="QRadioButton" name="kSpace_Cut_Outside_radioButton">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Outside to 0 [%]</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="29" column="4">
+     <widget class="QSpinBox" name="kSpace_Cut_Outside_spinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="minimum">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <number>100</number>
+      </property>
+      <property name="value">
+       <number>10</number>
+      </property>
+     </widget>
+    </item>
+    <item row="28" column="4">
+     <widget class="QSpinBox" name="kSpace_Cut_Center_spinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="minimum">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <number>100</number>
+      </property>
+      <property name="value">
+       <number>10</number>
+      </property>
+     </widget>
+    </item>
+    <item row="28" column="3">
+     <widget class="QRadioButton" name="kSpace_Cut_Center_radioButton">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Center to 0 [%]</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="27" column="3">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="kspace_cut_circ_radioButton">
+        <property name="minimumSize">
+         <size>
+          <width>75</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>75</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Circ</string>
+        </property>
+        <property name="autoExclusive">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="kspace_cut_rec_radioButton">
+        <property name="minimumSize">
+         <size>
+          <width>75</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>75</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Rec</string>
         </property>
         <property name="autoExclusive">
          <bool>false</bool>


### PR DESCRIPTION
Adds the funktion to set parts of the kspace to 0 in a circular mask around the isocenter. Its possible to set the center and/or the outside to 0. The function works together with the rectengular mask.

![2020-06-27-012259_1920x1080_scrot](https://user-images.githubusercontent.com/78707844/230586262-9169b482-c201-4060-a997-aff5a672b084.png)
