### PR TITLE
(feature) Add gradient scaling tool

### DIFF
--- a/Applications/relax2/Relax2_main.py
+++ b/Applications/relax2/Relax2_main.py
@@ -975,6 +975,30 @@ class ToolsWindow(Tools_Window_Form, Tools_Window_Base):
         self.Field_Map_Gradient_pushButton.clicked.connect(lambda: self.Field_Map_Gradient())
         self.Field_Map_Gradient_Slice_pushButton.clicked.connect(lambda: self.Field_Map_Gradient_Slice())
         
+        self.GradientScaling_XNominal_doubleSpinBox.setKeyboardTracking(False)
+        self.GradientScaling_XNominal_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesauto)
+        self.GradientScaling_YNominal_doubleSpinBox.setKeyboardTracking(False)
+        self.GradientScaling_YNominal_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesauto)
+        self.GradientScaling_ZNominal_doubleSpinBox.setKeyboardTracking(False)
+        self.GradientScaling_ZNominal_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesauto)
+        self.GradientScaling_XMeasured_doubleSpinBox.setKeyboardTracking(False)
+        self.GradientScaling_XMeasured_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesauto)
+        self.GradientScaling_YMeasured_doubleSpinBox.setKeyboardTracking(False)
+        self.GradientScaling_YMeasured_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesauto)
+        self.GradientScaling_ZMeasured_doubleSpinBox.setKeyboardTracking(False)
+        self.GradientScaling_ZMeasured_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesauto)
+        
+        self.Gradient_XScaling_doubleSpinBox.setKeyboardTracking(False)
+        self.Gradient_XScaling_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesmanual)
+        self.Gradient_YScaling_doubleSpinBox.setKeyboardTracking(False)
+        self.Gradient_YScaling_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesmanual)
+        self.Gradient_ZScaling_doubleSpinBox.setKeyboardTracking(False)
+        self.Gradient_ZScaling_doubleSpinBox.valueChanged.connect(self.update_gradsenstoolvaluesmanual)
+        
+        self.Apply_XScaling_pushButton.clicked.connect(lambda: self.set_gradsens_X())
+        self.Apply_YScaling_pushButton.clicked.connect(lambda: self.set_gradsens_Y())
+        self.Apply_ZScaling_pushButton.clicked.connect(lambda: self.set_gradsens_Z())
+        
     def load_params(self):
         self.AC_Start_Frequency_doubleSpinBox.setValue(params.ACstart)
         self.AC_Stop_Frequency_doubleSpinBox.setValue(params.ACstop)
@@ -991,6 +1015,18 @@ class ToolsWindow(Tools_Window_Form, Tools_Window_Base):
         if params.ToolShimChannel[1] == 1: self.Tool_Shim_Y_radioButton.setChecked(True)
         if params.ToolShimChannel[2] == 1: self.Tool_Shim_Z_radioButton.setChecked(True)
         if params.ToolShimChannel[3] == 1: self.Tool_Shim_Z2_radioButton.setChecked(True)
+        
+        self.GradientScaling_XNominal_doubleSpinBox.setValue(params.gradnominal[0])
+        self.GradientScaling_YNominal_doubleSpinBox.setValue(params.gradnominal[1])
+        self.GradientScaling_ZNominal_doubleSpinBox.setValue(params.gradnominal[2])
+        
+        self.GradientScaling_XMeasured_doubleSpinBox.setValue(params.gradmeasured[0])
+        self.GradientScaling_YMeasured_doubleSpinBox.setValue(params.gradmeasured[1])
+        self.GradientScaling_ZMeasured_doubleSpinBox.setValue(params.gradmeasured[2])
+        
+        self.Gradient_XScaling_doubleSpinBox.setValue(params.gradsenstool[0])
+        self.Gradient_YScaling_doubleSpinBox.setValue(params.gradsenstool[1])
+        self.Gradient_ZScaling_doubleSpinBox.setValue(params.gradsenstool[2])
         
     def update_params(self):
         params.ACstart = self.AC_Start_Frequency_doubleSpinBox.value()
@@ -1014,6 +1050,53 @@ class ToolsWindow(Tools_Window_Form, Tools_Window_Base):
         else: params.ToolShimChannel[3] = 0
         
         params.saveFileParameter()
+        
+    def update_gradsenstoolvaluesauto(self):
+        params.gradnominal[0] = self.GradientScaling_XNominal_doubleSpinBox.value()
+        params.gradnominal[1] = self.GradientScaling_YNominal_doubleSpinBox.value()
+        params.gradnominal[2] = self.GradientScaling_ZNominal_doubleSpinBox.value()
+        params.gradmeasured[0] = self.GradientScaling_XMeasured_doubleSpinBox.value()
+        params.gradmeasured[1] = self.GradientScaling_YMeasured_doubleSpinBox.value()
+        params.gradmeasured[2] = self.GradientScaling_ZMeasured_doubleSpinBox.value()
+        
+        params.gradsenstool[0] = params.gradmeasured[0]/params.gradnominal[0] * params.gradsens[0]
+        params.gradsenstool[1] = params.gradmeasured[1]/params.gradnominal[1] * params.gradsens[1]
+        params.gradsenstool[2] = params.gradmeasured[2]/params.gradnominal[2] * params.gradsens[2]
+
+        self.Gradient_XScaling_doubleSpinBox.setValue(params.gradsenstool[0])
+        self.Gradient_YScaling_doubleSpinBox.setValue(params.gradsenstool[1])
+        self.Gradient_ZScaling_doubleSpinBox.setValue(params.gradsenstool[2])
+        
+        params.saveFileParameter()
+        
+    def update_gradsenstoolvaluesmanual(self):
+        params.gradsenstool[0] = self.Gradient_XScaling_doubleSpinBox.value()
+        params.gradsenstool[1] = self.Gradient_YScaling_doubleSpinBox.value()
+        params.gradsenstool[2] = self.Gradient_ZScaling_doubleSpinBox.value()
+        
+        params.saveFileParameter()
+        
+    def set_gradsens_X(self):
+        print('Set X gradient sensitivity from ' + str(params.gradsens[0]) + 'mT/m/A to ' + str(params.gradsenstool[0]) + 'mT/m/A!')
+        
+        params.gradsens[0] = params.gradsenstool[0]
+        
+        params.saveFileParameter()
+        
+    def set_gradsens_Y(self):
+        print('Set Y gradient sensitivity from ' + str(params.gradsens[1]) + 'mT/m/A to ' + str(params.gradsenstool[1]) + 'mT/m/A!')
+        
+        params.gradsens[1] = params.gradsenstool[1]
+        
+        params.saveFileParameter()
+        
+    def set_gradsens_Z(self):
+        print('Set Z gradient sensitivity from ' + str(params.gradsens[2]) + 'mT/m/A to ' + str(params.gradsenstool[2]) + 'mT/m/A!')
+        
+        params.gradsens[2] = params.gradsenstool[2]
+        
+        params.saveFileParameter()
+        
         
     def Autocentertool(self):
         if params.connectionmode == 1:
@@ -1111,7 +1194,7 @@ class ToolsWindow(Tools_Window_Form, Tools_Window_Base):
             
             proc.FieldMapB0()
             
-            #self.IMag_fig = Figure(); self.IMag_canvas = FigureCanvas(self.IMag_fig); self.IMag_fig.set_facecolor("None");
+            #self.IMag_fig = Figure(); self.IMag_canvas = FigureCanvas(self.IMag_fig); self.IMag_fig.set_facecolor("None")
             #self.IMag_ax = self.IMag_fig.add_subplot(111); self.IMag_ax.grid(False); self.IMag_ax.axis(frameon=False)
             #self.IMag_ax.imshow(params.img_mag, cmap='viridis'); self.IMag_ax.axis('off'); self.IMag_ax.set_aspect(1.0/self.IMag_ax.get_data_ratio())
             #self.IMag_ax.set_title('Magnitude Image')
@@ -1148,7 +1231,7 @@ class ToolsWindow(Tools_Window_Form, Tools_Window_Base):
             
             proc.FieldMapB0Slice()
             
-            #self.IMag_fig = Figure(); self.IMag_canvas = FigureCanvas(self.IMag_fig); self.IMag_fig.set_facecolor("None");
+            #self.IMag_fig = Figure(); self.IMag_canvas = FigureCanvas(self.IMag_fig); self.IMag_fig.set_facecolor("None")
             #self.IMag_ax = self.IMag_fig.add_subplot(111); self.IMag_ax.grid(False); self.IMag_ax.axis(frameon=False)
             #self.IMag_ax.imshow(params.img_mag, cmap='viridis'); self.IMag_ax.axis('off'); self.IMag_ax.set_aspect(1.0/self.IMag_ax.get_data_ratio())
             #self.IMag_ax.set_title('Magnitude Image')
@@ -1239,11 +1322,77 @@ class ToolsWindow(Tools_Window_Form, Tools_Window_Base):
         if params.connectionmode == 1:
             print('\033[1m' + 'WIP Field_Map_Gradient' + '\033[0m')
             
+            proc.FieldMapGradient()
+            
+            self.IMag_fig = Figure()
+            self.IMag_canvas = FigureCanvas(self.IMag_fig)
+            self.IMag_fig.set_facecolor("None")
+            self.IMag_ax = self.IMag_fig.add_subplot(111)
+            self.IMag_ax.imshow(params.img_mag, interpolation='gaussian', cmap='viridis', extent=[(-params.FOV/2),(params.FOV/2),(-params.FOV/2),(params.FOV/2)])
+            self.IMag_ax.set_aspect(1.0/self.IMag_ax.get_data_ratio())
+            self.IMag_ax.set_title('Magnitude Image')
+            self.major_ticks = np.linspace(math.ceil((-params.FOV/2)),math.floor((params.FOV/2)),math.floor((params.FOV/2))-math.ceil((-params.FOV/2))+1)
+            self.minor_ticks = np.linspace((math.ceil((-params.FOV/2)*5))/5,(math.floor((params.FOV/2)*5))/5,math.floor((params.FOV/2)*5)-math.ceil((-params.FOV/2)*5)+1)
+            self.IMag_ax.set_xticks(self.major_ticks)
+            self.IMag_ax.set_xticks(self.minor_ticks, minor=True)
+            self.IMag_ax.set_yticks(self.major_ticks)
+            self.IMag_ax.set_yticks(self.minor_ticks, minor=True)
+            self.IMag_ax.grid(which='major', color='#CCCCCC', linestyle='--')
+            self.IMag_ax.grid(which='minor', color='#CCCCCC', linestyle=':')
+            
+            if params.imageorientation == 0:
+                self.IMag_ax.set_xlabel('X in mm')
+                self.IMag_ax.set_ylabel('Y in mm')
+            elif params.imageorientation == 1:
+                self.IMag_ax.set_xlabel('Y in mm')
+                self.IMag_ax.set_ylabel('Z in mm')
+            elif params.imageorientation == 2:
+                self.IMag_ax.set_xlabel('Z in mm')
+                self.IMag_ax.set_ylabel('X in mm')
+                
+            self.IMag_canvas.draw()
+            self.IMag_canvas.setWindowTitle('Tool Plot - ' + params.datapath + '.txt')
+            self.IMag_canvas.setGeometry(820, 40, 800, 750)
+            self.IMag_canvas.show()
+            
         else: print('Not allowed in offline mode!')
 
     def Field_Map_Gradient_Slice(self):
         if params.connectionmode == 1:
             print('\033[1m' + 'WIP Field_Map_Gradient_Slice' + '\033[0m')
+            
+            proc.FieldMapGradientSlice()
+            
+            self.IMag_fig = Figure()
+            self.IMag_canvas = FigureCanvas(self.IMag_fig)
+            self.IMag_fig.set_facecolor("None")
+            self.IMag_ax = self.IMag_fig.add_subplot(111)
+            self.IMag_ax.imshow(params.img_mag, interpolation='gaussian', cmap='viridis', extent=[(-params.FOV/2),(params.FOV/2),(-params.FOV/2),(params.FOV/2)])
+            self.IMag_ax.set_aspect(1.0/self.IMag_ax.get_data_ratio())
+            self.IMag_ax.set_title('Magnitude Image')
+            self.major_ticks = np.linspace(math.ceil((-params.FOV/2)),math.floor((params.FOV/2)),math.floor((params.FOV/2))-math.ceil((-params.FOV/2))+1)
+            self.minor_ticks = np.linspace((math.ceil((-params.FOV/2)*5))/5,(math.floor((params.FOV/2)*5))/5,math.floor((params.FOV/2)*5)-math.ceil((-params.FOV/2)*5)+1)
+            self.IMag_ax.set_xticks(self.major_ticks)
+            self.IMag_ax.set_xticks(self.minor_ticks, minor=True)
+            self.IMag_ax.set_yticks(self.major_ticks)
+            self.IMag_ax.set_yticks(self.minor_ticks, minor=True)
+            self.IMag_ax.grid(which='major', color='#CCCCCC', linestyle='--')
+            self.IMag_ax.grid(which='minor', color='#CCCCCC', linestyle=':')
+            
+            if params.imageorientation == 0:
+                self.IMag_ax.set_xlabel('X in mm')
+                self.IMag_ax.set_ylabel('Y in mm')
+            elif params.imageorientation == 1:
+                self.IMag_ax.set_xlabel('Y in mm')
+                self.IMag_ax.set_ylabel('Z in mm')
+            elif params.imageorientation == 2:
+                self.IMag_ax.set_xlabel('Z in mm')
+                self.IMag_ax.set_ylabel('X in mm')
+                
+            self.IMag_canvas.draw()
+            self.IMag_canvas.setWindowTitle('Tool Plot - ' + params.datapath + '.txt')
+            self.IMag_canvas.setGeometry(820, 40, 800, 750)
+            self.IMag_canvas.show()
             
         else: print('Not allowed in offline mode!')
 

--- a/Applications/relax2/parameter_handler.py
+++ b/Applications/relax2/parameter_handler.py
@@ -158,6 +158,9 @@ class Parameters:
         self.FOV = 20.0
         self.slicethickness = 5.0
         self.gradsens = [33.5, 31.9, 32.5]
+        self.gradnominal = [10.0, 10.0, 10.0]
+        self.gradmeasured = [10.0, 10.0, 10.0]
+        self.gradsenstool = [33.5, 31.9, 32.5]
         self.autofreqoffset = 1
         self.sliceoffset = 0
         self.animationstep = 100
@@ -278,6 +281,9 @@ class Parameters:
                          self.FOV, \
                          self.slicethickness, \
                          self.gradsens, \
+                         self.gradnominal, \
+                         self.gradmeasured, \
+                         self.gradsenstool, \
                          self.autofreqoffset, \
                          self.sliceoffset, \
                          self.animationstep, \
@@ -431,6 +437,9 @@ class Parameters:
                 self.FOV, \
                 self.slicethickness, \
                 self.gradsens, \
+                self.gradnominal, \
+                self.gradmeasured, \
+                self.gradsenstool, \
                 self.autofreqoffset, \
                 self.sliceoffset, \
                 self.animationstep, \

--- a/Applications/relax2/process_handler.py
+++ b/Applications/relax2/process_handler.py
@@ -1041,6 +1041,49 @@ class process:
         params.GUImode = self.GUImodetemp
         params.sequence = self.sequencetemp
         params.datapath = self.datapathtemp
+        
+    def FieldMapGradient(self):
+        print('Gradient tool started...')
+        
+        self.GUImodetemp = 0
+        self.sequencetemp = 0
+        self.datapathtemp = ''
+        self.GUImodetemp = params.GUImode
+        self.sequencetemp = params.sequence
+        self.datapathtemp = params.datapath
+        
+        params.GUImode = 1
+        params.sequence = 5
+        params.datapath = 'rawdata/Tool_rawdata'
+        
+        seq.sequence_upload()
+        proc.image_process()
+        
+        params.GUImode = self.GUImodetemp
+        params.sequence = self.sequencetemp
+        params.datapath = self.datapathtemp
+        
+    def FieldMapGradientSlice(self):
+        print('Gradient (Slice) tool started...')
+        
+        self.GUImodetemp = 0
+        self.sequencetemp = 0
+        self.datapathtemp = ''
+        self.GUImodetemp = params.GUImode
+        self.sequencetemp = params.sequence
+        self.datapathtemp = params.datapath
+        
+        params.GUImode = 1
+        params.sequence = 21
+        params.datapath = 'rawdata/Tool_rawdata'
+        
+        seq.sequence_upload()
+        proc.image_process()
+        
+        params.GUImode = self.GUImodetemp
+        params.sequence = self.sequencetemp
+        params.datapath = self.datapathtemp
+        
 
     def T1measurement_IR_FID(self):
         print('Measuring T1...')

--- a/Applications/relax2/ui/tools.ui
+++ b/Applications/relax2/ui/tools.ui
@@ -980,28 +980,6 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="3">
-     <widget class="QPushButton" name="Field_Map_Gradient_Slice_pushButton">
-      <property name="minimumSize">
-       <size>
-        <width>150</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>150</width>
-        <height>30</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Gradient Slice</string>
-      </property>
-      <property name="autoDefault">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
     <item row="1" column="2">
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="spacing">
@@ -1060,7 +1038,7 @@
       </item>
      </layout>
     </item>
-    <item row="3" column="2">
+    <item row="4" column="2">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <property name="spacing">
        <number>0</number>
@@ -1079,8 +1057,13 @@
           <height>30</height>
          </size>
         </property>
+        <property name="font">
+         <font>
+          <pointsize>11</pointsize>
+         </font>
+        </property>
         <property name="text">
-         <string>Gradient</string>
+         <string>Test Image (SE)</string>
         </property>
         <property name="autoDefault">
          <bool>false</bool>
@@ -1088,6 +1071,625 @@
        </widget>
       </item>
      </layout>
+    </item>
+    <item row="4" column="3">
+     <widget class="QPushButton" name="Field_Map_Gradient_Slice_pushButton">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Test Image (SE Slice)</string>
+      </property>
+      <property name="autoDefault">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="2">
+     <widget class="QLabel" name="label_16">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <weight>75</weight>
+        <bold>true</bold>
+       </font>
+      </property>
+      <property name="text">
+       <string>Gradient Scaling</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="3">
+     <widget class="QDoubleSpinBox" name="GradientScaling_XMeasured_doubleSpinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="decimals">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <double>1000.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="2">
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QDoubleSpinBox" name="GradientScaling_XNominal_doubleSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>150</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>10.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="5" column="2">
+     <widget class="QLabel" name="label_17">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>X Nominal [mm]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="3">
+     <widget class="QLabel" name="label_18">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>X Measured [mm]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="16" column="3">
+     <widget class="QPushButton" name="Apply_ZScaling_pushButton">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Apply Z Scaling</string>
+      </property>
+      <property name="autoDefault">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="15" column="3">
+     <widget class="QDoubleSpinBox" name="Gradient_ZScaling_doubleSpinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="decimals">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <double>300.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>35.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="14" column="3">
+     <widget class="QDoubleSpinBox" name="GradientScaling_ZMeasured_doubleSpinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="decimals">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <double>1000.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="13" column="3">
+     <widget class="QLabel" name="label_22">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Z Measured [mm]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="14" column="2">
+     <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QDoubleSpinBox" name="GradientScaling_ZNominal_doubleSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>150</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>10.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="13" column="2">
+     <widget class="QLabel" name="label_21">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Z Nominal [mm]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="12" column="3">
+     <widget class="QPushButton" name="Apply_YScaling_pushButton">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Apply Y Scaling</string>
+      </property>
+      <property name="autoDefault">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="11" column="3">
+     <widget class="QDoubleSpinBox" name="Gradient_YScaling_doubleSpinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="decimals">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <double>300.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>35.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="10" column="3">
+     <widget class="QDoubleSpinBox" name="GradientScaling_YMeasured_doubleSpinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="decimals">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <double>1000.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="10" column="2">
+     <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QDoubleSpinBox" name="GradientScaling_YNominal_doubleSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>150</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>10.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="9" column="2">
+     <widget class="QLabel" name="label_19">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Y Nominal [mm]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="3">
+     <widget class="QLabel" name="label_20">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Y Measured [mm]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="3">
+     <widget class="QPushButton" name="Apply_XScaling_pushButton">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Apply X Scaling</string>
+      </property>
+      <property name="autoDefault">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="3">
+     <widget class="QDoubleSpinBox" name="Gradient_XScaling_doubleSpinBox">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>150</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="decimals">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <double>300.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>35.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="2">
+     <widget class="QLabel" name="label_23">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>26</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>X Scaling [mT/m/A]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="11" column="2">
+     <widget class="QLabel" name="label_24">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Y Scaling [mT/m/A]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="15" column="2">
+     <widget class="QLabel" name="label_25">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>30</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Y Scaling [mT/m/A]</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
This PR adds a gradient scaling tool to the "Tool" window.

The "Test Image" buttons will acquire a SE or SE slice image and plot the image in a grid scaled on the current FOV. Also the axis labels will change with the current image orientation. The image has a gaussian filter to make sample shapes more visible.

With the image grid you can measure the test sample and comare it with its nominal dimensions.
These values can be changed in the "Tools" window. A new scaling factor is calculated automatically. By applying the new scaling factor the current scaling factor gets overwritten. The new scaling factor can also be changed manually.

The example image shows a 64x64 pixel image of a chemical test tube sample. The (black) plastic sample has a nominal diameter of 8.4mm.

![2020-06-28-030633_1920x1080_scrot](https://user-images.githubusercontent.com/78707844/232313612-e9d365e4-2b1e-47c4-bf03-7766cc336d53.png)
