### PR TITLE
(fix/feature)  T time measurement stability and rawdata examples

### DIFF
--- a/Applications/relax2/process_handler.py
+++ b/Applications/relax2/process_handler.py
@@ -1088,6 +1088,7 @@ class process:
     def T1measurement_IR_FID(self):
         print('Measuring T1...')
         
+        self.TItemp = 0
         self.TItemp = params.TI
         
         self.T1steps = np.linspace(params.TIstart,params.TIstop,params.TIsteps)
@@ -1107,6 +1108,8 @@ class process:
             print(n+1, '/', params.TIsteps)
             self.T1steps[n] = round(self.T1steps[n],1)
             params.TI = self.T1steps[n]
+            params.frequency = params.centerfrequency
+            params.saveFileParameter()
             seq.IR_FID_setup()
             seq.Sequence_upload()
             seq.acquire_spectrum_FID()
@@ -1129,6 +1132,7 @@ class process:
     def T1measurement_IR_SE(self):
         print('Measuring T1...')
         
+        self.TItemp = 0
         self.TItemp = params.TI
         
         self.T1steps = np.linspace(params.TIstart,params.TIstop,params.TIsteps)
@@ -1148,6 +1152,8 @@ class process:
             print(n+1, '/', params.TIsteps)
             self.T1steps[n] = round(self.T1steps[n],1)
             params.TI = self.T1steps[n]
+            params.frequency = params.centerfrequency
+            params.saveFileParameter()
             seq.IR_SE_setup()
             seq.Sequence_upload()
             seq.acquire_spectrum_SE()
@@ -1208,6 +1214,7 @@ class process:
     def T2measurement_SE(self):
         print('Measuring T2...')
         
+        self.TEtemp = 0
         self.TEtemp = params.TE
         
         self.T2steps = np.linspace(params.TEstart,params.TEstop,params.TEsteps)
@@ -1227,6 +1234,8 @@ class process:
             print(n+1, '/', params.TEsteps)
             self.T2steps[n] = round(self.T2steps[n],1)
             params.TE = self.T2steps[n]
+            params.frequency = params.centerfrequency
+            params.saveFileParameter()
             seq.SE_setup()
             seq.Sequence_upload()
             seq.acquire_spectrum_SE()
@@ -1249,6 +1258,7 @@ class process:
     def T2measurement_SIR_FID(self):
         print('Measuring T2...')
         
+        self.TEtemp = 0
         self.TEtemp = params.TE
         
         self.T2steps = np.linspace(params.TEstart,params.TEstop,params.TEsteps)
@@ -1257,6 +1267,8 @@ class process:
         
         self.T2steps[0] = round(self.T2steps[0],1)
         params.TE = self.T2steps[0]
+        params.frequency = params.centerfrequency
+        params.saveFileParameter()
         seq.SIR_FID_setup()
         seq.Sequence_upload()
         seq.acquire_spectrum_SE()

--- a/Applications/relax2/rawdata/rawdata.txt
+++ b/Applications/relax2/rawdata/rawdata.txt
@@ -1,1 +1,26 @@
-In this folder you will find the acquired raw data.
+In this folder you will find the acquired rawdata.
+
+Example rawdata can be downloaded here:
+https://data.stimulate.ovgu.de/f/675009ce02fa4cbda49d/
+
+There is rawdata for:
+- Spectroscopy - SE
+- Spectroscopy - FID
+- Projections - SE on axis
+- Imaging - Radial SE Full
+- Imaging - SE
+- Imaging - GRE
+- T1 Measurement - IR SE
+- T2 Measurement - SE
+
+1.) Copy the rawdata into the relax2/rawdata folder.
+
+2.) Choose the matching modality and sequence in the Relax2.0 GUI main window.
+
+3.) Overwrite the rawdata path name in the Relax2.0 main window, like: 
+    rawdata/Exsample_Image_rawdata_2Holes_2DSE_TE10ms_TS3ms_TR4s_FOV12mm_Res128
+
+4.) Click on "Data Process" in the Relax2.0 main window. 
+
+Hints: Its nomally not necessary to enter the parameters. There are only a few exeptions like 3D slice or 3D FFT imaging.
+

--- a/Applications/relax2/rawdata/rawdata.txt
+++ b/Applications/relax2/rawdata/rawdata.txt
@@ -1,6 +1,6 @@
 In this folder you will find the acquired rawdata.
 
-Example rawdata can be downloaded here:
+Exsample rawdata can be downloaded here:
 https://data.stimulate.ovgu.de/f/675009ce02fa4cbda49d/
 
 There is rawdata for:

--- a/utils/load_fpga_bit.sh
+++ b/utils/load_fpga_bit.sh
@@ -5,7 +5,7 @@ if [ -d /sys/kernel/config/device-tree/overlays/full ]; then
 fi
 
 echo 0 > /sys/class/fpga_manager/fpga0/flags
-cp ~/ocra_mri.bit.bin ~/ocra_mri.dtbo /lib/firmware/
+cp ~/stemlab_125_14_ocra_mri.bit.bin ~/stemlab_125_14_ocra_mri.dtbo /lib/firmware/
 
 mkdir /sys/kernel/config/device-tree/overlays/full
-echo -n "ocra_mri.dtbo" > /sys/kernel/config/device-tree/overlays/full/path
+echo -n "stemlab_125_14_ocra_mri.dtbo" > /sys/kernel/config/device-tree/overlays/full/path


### PR DESCRIPTION
Accurate T1 and T2 mesurement takes time. Over langer times the Tabletop will drift away. This causes weaker signals to the end of the T time mesurement and will ruin the data fitting. This fix will add the centerfrequency auto-readjust on each measurement point. This improoves the data and fitting drastically.

The offline mode of the Relax2.0 GUI allows for data reconstruction and plotting without a console. I added a link to a .zip file with nice example rawdata to play arround. I also added a small description on how to load the example rawdata.

Edit: Dont know why its doing 3 commits. I only pushed the last one.