### PR TITLE
Add functionality for json header export and set this to default

### DIFF
--- a/Applications/relax2/Relax2_main.py
+++ b/Applications/relax2/Relax2_main.py
@@ -313,8 +313,10 @@ class MainWindow(Main_Window_Base, Main_Window_Form):
                         seq.sequence_upload()
                 else: seq.sequence_upload()
             else: seq.sequence_upload()
-            params.save_header_file()
-        else: print('\033[1m' + 'Not allowed in offline mode!' + '\033[0m')
+            params.save_header_file_json()
+        else:
+            print('\033[1m' + 'Not allowed in offline mode!' + '\033[0m')
+            params.save_header_file_json()
         if self.dialog_params != None:
             self.dialog_params.load_params()
             self.dialog_params.repaint()
@@ -2011,8 +2013,10 @@ class ProtocolWindow(Protocol_Window_Form, Protocol_Window_Base):
                         seq.sequence_upload()
                 else: seq.sequence_upload()
             else: seq.sequence_upload()
-            params.save_header_file()
-        else: print('\033[1m' + 'Not allowed in offline mode!' + '\033[0m')
+            params.save_header_file_json()
+        else:
+            print('\033[1m' + 'Not allowed in offline mode!' + '\033[0m')
+            params.save_header_file_json()
 
 
 class PlotWindow(Plot_Window_Form, Plot_Window_Base):

--- a/Applications/relax2/parameter_handler.py
+++ b/Applications/relax2/parameter_handler.py
@@ -10,6 +10,7 @@
 
 import sys
 import pickle
+import json
 from PyQt5.QtCore import QFile, QTextStream
 from cycler import cycler
 
@@ -691,7 +692,99 @@ class Parameters:
         file.write('SAR status: ' + str(self.SAR_status) + '\n')
         
         file.close()
-        
+
+    def save_header_file_json(self):
+        filename = params.datapath + '_Header.json'
+
+        header_dict = {
+            'Hosts': self.hosts,
+            'Connection mode': self.connectionmode,
+            'GUI mode': self.GUImode,
+            'Sequence': self.sequence,
+            'Sequence file': self.sequencefile,
+            'Data path': self.datapath,
+            'Frequency [MHz]': self.frequency,
+            'Auto recenter': self.autorecenter,
+            'RF frequency offset [Hz]':
+                -self.frequencyoffset if self.frequencyoffsetsign == 1
+                else self.frequencyoffset,
+            'RF phase offset [°]': self.phaseoffset,
+            'RF phase offset [rad]': self.phaseoffsetradmod100,
+            'RF pulse length [µs]': self.RFpulselength,
+            'RF pulse amplitude': self.RFpulseamplitude,
+            'Flip angle (time) [°]': self.flipangletime,
+            'Flip angle (amplitude) [°]': self.flipangleamplitude,
+            'Flip pulse length [µs]': self.flippulselength,
+            'Flip pulse amplitude': self.flippulseamplitude,
+            'RF attenuation [dB]': self.RFattenuation,
+            'RX port 1': self.rx1,
+            'RX port 2': self.rx2,
+            'RX mode': self.rxmode,
+            'RX scaling': self.RXscaling,
+            'TS [ms]': self.TS,
+            'Readout bandwidth scaling': self.ROBWscaler,
+            'TE [ms]': self.TE,
+            'TI [ms]': self.TI,
+            'TR [ms]': self.TR,
+            'Shim values [mA]': list(self.grad),
+            'Gradient orientation': list(self.Gradientorientation),
+            'Image orientation': 'XY' if self.imageorientation == 0
+            else ('YZ'
+                  if self.imageorientation == 1
+                  else 'ZX'),
+            'Image resolution index': self.imageresolution,
+            'Image resolution [pixel]': self.nPE,
+            'Frequency range [Hz]': self.frequencyrange,
+            'Samples': self.samples,
+            'Sampledelay': self.sampledelay,
+            'Timestamp': self.dataTimestamp,
+            'TI start [ms]': self.TIstart,
+            'TI stop [ms]': self.TIstop,
+            'TI steps': self.TIsteps,
+            'TE start [ms]': self.TEstart,
+            'TE stop [ms]': self.TEstop,
+            'TE steps': self.TEsteps,
+            'Projection axes': list(self.projaxis),
+            'Average': self.average,
+            'Number of averages': self.averagecount,
+            'Projection gradient amplitude [mA]': list(self.Gproj),
+            'Projection angle [°]': self.projectionangle,
+            'Projection angle [rad]': self.projectionangleradmod100,
+            'Readout gradient amplitude [mA]': self.GROamplitude,
+            'Phase gradient step amplitude [mA]': self.GPEstep,
+            'Slice gradient amplitude [mA]': self.GSamplitude,
+            '3D phase gradient step amplitude [mA]:': self.GSPEstep,
+            '3D phase steps': self.SPEsteps,
+            'Diffusion gradient amplitude [mA]': self.Gdiffamplitude,
+            'Crusher gradient amplitude [mA]': self.crusheramplitude,
+            'Spoiler gradient amplitude [mA]': self.spoileramplitude,
+            'Readout gradient prephaser duration [µs]': self.GROpretime,
+            'Readout gradient prephaser duration scaling': self.GROpretimescaler,
+            'Slice gradient rephaser time [µs]': self.GSposttime,
+            'Crusher gradient duration [µs]': self.crushertime,
+            'Spoiler gradient duration [µs]': self.spoilertime,
+            'Diffusion gradient duration [µs]': self.diffusiontime,
+            'Fluid compensation readout gradient prephaser 1 duration [µs]':
+                self.GROfcpretime1,
+            'Fluid compensation readout gradient prephaser 2 duration [µs]':
+                self.GROfcpretime2,
+            'Radial angle [°]': self.radialanglestep,
+            'Radial angle [rad]': self.radialanglestepradmod100,
+            'Auto gradients': self.autograd,
+            'FOV [mm]': self.FOV,
+            'Slice/Slab thickness [mm]': self.slicethickness,
+            'Gradient sensitivity [mT/m/A]': list(self.gradsens),
+            'Auto frequency offset': self.autofreqoffset,
+            'Slice offset [mm]': self.sliceoffset,
+            'SAR enable': self.SAR_enable,
+            'SAR limit [W]': self.SAR_limit,
+            'SAR status': self.SAR_status
+        }
+
+        out_file = open(filename, "w")
+
+        json.dump(header_dict, out_file, ensure_ascii=False, indent=4)
+
     def load_GUItheme(self):
         file = QFile(':/' + self.GUIthemestr[self.GUItheme] + '.qss')
         file.open(QFile.ReadOnly | QFile.Text)


### PR DESCRIPTION
This PR sets export of head file to .json instead of .txt and updates the call to this method also in the main. The old method for text export still exists, if the default should be text export, please switch back to `save_header_file()`. 